### PR TITLE
Bump flowless to 0.7.1 and cljfx to 1.7.24

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
-{:deps {org.fxmisc.flowless/flowless {:mvn/version "0.6.10"}
-        cljfx/cljfx {:mvn/version "1.7.19"}}
+{:deps {org.fxmisc.flowless/flowless {:mvn/version "0.7.1"}
+        cljfx/cljfx {:mvn/version "1.7.24"}}
 
  :aliases {;; clj -T:build deploy
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}


### PR DESCRIPTION
First of all, thanks heaps for the nice wrapper. It's saved me a great deal of time. 👍🏼 

I've added `cljfx/flowless` to `deps.edn` in my project and have noticed that it was pulling old dependencies. 

A couple of things I've done to ensure the version bump is safe:
- Checked everything still runs after the version bump. 
- Skimmed through the change logs in both of the bumped projects and couldn't see any breaking API changes.

Please let me know if anything else is required to merge this PR. Cheers.